### PR TITLE
Add `focus-within` to `on-event` mixin

### DIFF
--- a/stylesheets/abstracts/_mixins.scss
+++ b/stylesheets/abstracts/_mixins.scss
@@ -11,13 +11,15 @@
     &,
     &:hover,
     &:active,
-    &:focus {
+    &:focus,
+    &:focus-within {
       @content;
     }
   } @else {
     &:hover,
     &:active,
-    &:focus {
+    &:focus,
+    &:focus-within {
       @content;
     }
   }


### PR DESCRIPTION
From the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within):

> The `:focus-mixin` CSS pseudo-class matches an element if the element or any of its descendants are focused. […]

This seems to me to be a valuable addition to the mixin.